### PR TITLE
Add WebStore healthchecks

### DIFF
--- a/EndPointCommerce.WebStore/Program.cs
+++ b/EndPointCommerce.WebStore/Program.cs
@@ -35,6 +35,8 @@ builder.Services.AddHttpClient<IApiClient, ApiClient>(client => {
     );
 });
 
+builder.Services.AddHealthChecks();
+
 builder.Host.UseSerilog((context, loggerConfig) =>
     loggerConfig.ReadFrom.Configuration(context.Configuration)
 );
@@ -70,5 +72,7 @@ app.UseSession();
 
 app.UseStaticFiles();
 app.MapRazorPages();
+
+app.MapHealthChecks("/healthz");
 
 app.Run();

--- a/compose.yaml
+++ b/compose.yaml
@@ -111,6 +111,12 @@ services:
       - AuthNetLoginId=${AUTH_NET_LOGIN_ID}
       - AuthNetClientKey=${AUTH_NET_CLIENT_KEY}
     entrypoint: [ "sh", "-c", "dotnet EndPointCommerce.WebStore.dll" ]
+    depends_on:
+      web-api:
+        condition: service_healthy
+    healthcheck:
+      test: 'curl -f -LI http://localhost:8080/healthz'
+      start_period: 30s
     logging: *default-logging
 
   db:


### PR DESCRIPTION
Just an extra nice-to-have.

The health check here is extremely bare-bones. No actual dependencies checked, so more of a "readiness" check I suppose in its present state.